### PR TITLE
Error when additional pipes are in the extensions

### DIFF
--- a/src/main/scala/com/bp/sds/cef/CefRecordParser.scala
+++ b/src/main/scala/com/bp/sds/cef/CefRecordParser.scala
@@ -90,7 +90,7 @@ private[cef] class CefRecordParser(options: CefParserOptions) extends Logging {
       rowData += (f.name -> null)
     )
 
-    val cefSplit = cef.split('|')
+    val cefSplit = cef.split("""(?<!\\)\|""", 8)
 
     try {
       rowData("CEFVersion") = UTF8String.fromString(cefSplit(0))

--- a/src/test/resources/cef-records/header-pipes-tests.cef
+++ b/src/test/resources/cef-records/header-pipes-tests.cef
@@ -1,0 +1,3 @@
+CEF:0|Incapsula|SIEMintegration|1|1|Illegal Resource Access|3| cs1=This|is some|test|data cs1Label=cs1
+CEF:0|Incapsula|SIEMintegration|1|1|Invalid \| Data|3| cs1=This|is some|test|data cs1Label=cs1
+CEF:0|Incapsula|SIEMintegration|1|1|Illegal Resource Access|3| cs1=This|is some|test|data cs1Label=cs1

--- a/src/test/scala/com/bp/sds/cef/CefDataSourceTests.scala
+++ b/src/test/scala/com/bp/sds/cef/CefDataSourceTests.scala
@@ -348,6 +348,18 @@ class CefDataSourceTests extends AnyFlatSpec with Matchers with BeforeAndAfterAl
     df.filter($"test".isNull).count() should be(1)
   }
 
+  it should "correctly handle multiple pipes in the record, and escaped pipes in the header" in {
+    val sourceFile = ResourceFileUtils.getFilePath("/cef-records/header-pipes-tests.cef")
+
+    import spark.implicits._
+
+    val df = spark.read
+      .cef(sourceFile)
+
+    df.filter($"Name" === """Invalid \| Data""").count() should be(1)
+    df.filter($"cs1" === "This|is some|test|data").count() should be(3)
+  }
+
   behavior of "Processing files with corrupt records"
 
   it should "capture the corrupt record in passive mode" in {

--- a/src/test/scala/com/bp/sds/cef/CefDataSourceTests.scala
+++ b/src/test/scala/com/bp/sds/cef/CefDataSourceTests.scala
@@ -398,7 +398,6 @@ class CefDataSourceTests extends AnyFlatSpec with Matchers with BeforeAndAfterAl
       .cef(sourceFile)
 
     val error = the[SparkException] thrownBy df.show()
-    println(error.getMessage)
     error.getMessage.contains("org.apache.spark.SparkException: Invalid rows detected") should be(true)
   }
 


### PR DESCRIPTION
Changes the record split to only split up to 8 times, and ignores pipes if they are escaped