### PR TITLE
Dazfuller/add writer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ pivotFields | Boolean | false | Read | Scans for field pairs in the format of `k
 defensiveMode | Boolean | false | Read | Used if a feed is known to violate the CEF spec. Adds overhead to the parsing so only use when there are known violations.
 nullValue | String | `-` | Read/Write | A value used in the CEF records which should be parsed as a `null` value.
 mode | ParseMode | Permissive | Read | Permitted values are "permissive" and "failfast". When used in `FailFast` mode the parser will throw an error on the first record exception found. When used in `Permissive` mode it will attempt to parse as much of the record as possible, with `null` values used for all other values. `Permissive` mode may be used in combination with the `corruptRecordColumnName` option.
-corruptRecordColumnName | String | `null` | Read | When used with `Permissive` mode the full record is stored in a column with the name provided. If null is provided then the full record is discarded. By providing a name the data source will append a column to the infered schema.
-dateFormat | String | `MMM dd yyyy HH:mm:ss.SSS zzz` | Write | When writing data out using the CEF standard this options defines the format time use for timestamp values. The data source will check against CEF valid formats. Alternatively use `millis` to output using millisecons from the epoch
+corruptRecordColumnName | String | `null` | Read | When used with `Permissive` mode the full record is stored in a column with the name provided. If null is provided then the full record is discarded. By providing a name the data source will append a column to the inferred schema.
+dateFormat | String | `MMM dd yyyy HH:mm:ss.SSS zzz` | Write | When writing data out using the CEF standard this options defines the format time use for timestamp values. The data source will check against CEF valid formats. Alternatively use `millis` to output using milliseconds from the epoch
 
 
 ### CEF supported date formats

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spark CEF Data Source
 
-A custom Spark data source supporting the [Common Event Format](https://support.citrix.com/article/CTX136146) standard
-for logging events.
+A custom Spark data source supporting the [Common Event Format](https://support.citrix.com/article/CTX136146) V25
+standard for logging events.
 
 ## Supported Features
 
@@ -9,7 +9,7 @@ for logging events.
 * Plain text, bzip2, and gzip files supported and tested
 * Field pivoting, for turning `<key>Label` fields into the field names
 * Scanning depth, allowing you to define how many records to scan to infer the schema
-* Built using Spark DataSource v2 APIs
+* Built using Spark DataSource v2 APIs for Spark 3
 * Usage as a source in Spark SQL statements
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -22,9 +22,16 @@ val spark = SparkSession.builder().getOrCreate()
 
 // Read using provided data frame reader
 val df = spark.read
-  .option("maxRecords", 10000)  // Default 10,000
-  .option("pivotFields", true)  // Default is false
+  .option("maxRecords", "10000")  // Optional, default 10,000
+  .option("pivotFields", "true")  // Optional, default is false
   .cef("/path/to/file.log")
+
+// Writing the data back out
+df.write
+  .mode("overwrite")
+  .option("nullValue", "NA")      // Optional
+  .option("dateFormat", "millis") // Optional
+  .cef("/path/to/output/file.log")
 
 // Or using the format method (required for use in PySpark)
 
@@ -52,11 +59,31 @@ FROM
 The following options are available to pass to the data source, where they are not defined then the default value
 will be used.
 
-Option | Type | Default | Purpose
------- | ---- | ------- | -------
-maxRecords | Integer | 10,000 | The number of records to scan when inferring the schema. The data source will keep scanning until either the maximum number of records have been reached or there are no more files to scan.
-pivotFields | Boolean | false | Scans for field pairs in the format of `key=value keyLabel=OtherKey` and pivots the data to `OtherKey=value`.
-defensiveMode | Boolean | false | Used if a feed is known to violate the CEF spec. Adds overhead to the parsing so only use when there are known violations.
-nullValue | String | `-` | A value used in the CEF records which should be parsed as a `null` value.
-mode | ParseMode | Permissive | Permitted values are "permissive" and "failfast". When used in `FailFast` mode the parser will throw an error on the first record exception found. When used in `Permissive` mode it will attempt to parse as much of the record as possible, with `null` values used for all other values. `Permissive` mode may be used in combination with the `corruptRecordColumnName` option.
-corruptRecordColumnName | String | `null` | When used with `Permissive` mode the full record is stored in a column with the name provided. If null is provided then the full record is discarded. By providing a name the data source will append a column to the infered schema.
+Option | Type | Default | Supported Actions | Purpose
+------ | ---- | ------- | ----------------- | -------
+maxRecords | Integer | 10,000 | Read | The number of records to scan when inferring the schema. The data source will keep scanning until either the maximum number of records have been reached or there are no more files to scan.
+pivotFields | Boolean | false | Read | Scans for field pairs in the format of `key=value keyLabel=OtherKey` and pivots the data to `OtherKey=value`.
+defensiveMode | Boolean | false | Read | Used if a feed is known to violate the CEF spec. Adds overhead to the parsing so only use when there are known violations.
+nullValue | String | `-` | Read/Write | A value used in the CEF records which should be parsed as a `null` value.
+mode | ParseMode | Permissive | Read | Permitted values are "permissive" and "failfast". When used in `FailFast` mode the parser will throw an error on the first record exception found. When used in `Permissive` mode it will attempt to parse as much of the record as possible, with `null` values used for all other values. `Permissive` mode may be used in combination with the `corruptRecordColumnName` option.
+corruptRecordColumnName | String | `null` | Read | When used with `Permissive` mode the full record is stored in a column with the name provided. If null is provided then the full record is discarded. By providing a name the data source will append a column to the infered schema.
+dateFormat | String | `MMM dd yyyy HH:mm:ss.SSS zzz` | Write | When writing data out using the CEF standard this options defines the format time use for timestamp values. The data source will check against CEF valid formats. Alternatively use `millis` to output using millisecons from the epoch
+
+
+### CEF supported date formats
+
+The following defines the date formats supported by the CEF standards. Also supported are epoch milliseconds which can 
+be requested using the `millis` format for `dateFormat` when writing. When reading the data source will also evaluate
+ISO 8601 formats for where non-standard date formats may have been used.
+
+    MMM dd yyyy HH:mm:ss
+    MMM dd yyyy HH:mm:ss.SSS zzz
+    MMM dd yyyy HH:mm:ss.SSS
+    MMM dd yyyy HH:mm:ss zzz
+    MMM dd HH:mm:ss
+    MMM dd HH:mm:ss.SSS zzz
+    MMM dd HH:mm:ss.SSS
+    MMM dd HH:mm:ss zzz
+
+When reading, if the timezone identifier is omitted, then UTC will be assumed. If the year is omitted then it will
+default to 1970.

--- a/src/main/scala/com/bp/sds/cef/CefDataIterator.scala
+++ b/src/main/scala/com/bp/sds/cef/CefDataIterator.scala
@@ -1,51 +1,28 @@
 package com.bp.sds.cef
 
-import java.io.{BufferedReader, InputStreamReader}
-import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
-
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.Path
-import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.util.{BadRecordException, FailFastMode, PermissiveMode}
+import org.apache.spark.sql.execution.datasources.{HadoopFileLinesReader, PartitionedFile}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.{SparkException, TaskContext}
 
-final class CefDataIterator(conf: Configuration, path: Path, dataSchema: StructType, requiredSchema: StructType, cefOptions: CefParserOptions) extends Iterator[InternalRow] with Logging {
+final class CefDataIterator(conf: Configuration, file: PartitionedFile, dataSchema: StructType, requiredSchema: StructType, cefOptions: CefParserOptions) extends Iterator[InternalRow] with Logging {
   private val parser = new CefRecordParser(cefOptions)
-  private var started: LocalDateTime = _
 
-  private val bufferedReader = new BufferedReader(new InputStreamReader(CefRecordParser.getReader(path, conf)))
+  private val bufferedReader = new HadoopFileLinesReader(file, conf)
+  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => bufferedReader.close()))
 
-  private var line: String = _
-
-  override def hasNext: Boolean = {
-    if (started == null) {
-      started = LocalDateTime.now()
-    }
-    line = bufferedReader.readLine()
-
-    if (line == null) {
-      if (started != null) {
-        val timeTaken = ChronoUnit.SECONDS.between(started, LocalDateTime.now)
-        logInfo(s"Processing file '${path.toUri}' took $timeTaken seconds")
-      }
-      logInfo(s"Completed reading file '${path.toUri}'")
-      bufferedReader.close()
-      false
-    } else {
-      true
-    }
-  }
+  override def hasNext: Boolean = bufferedReader.hasNext
 
   override def next(): InternalRow = {
     try {
-      parser.parseToInternalRow(line, requiredSchema)
+      parser.parseToInternalRow(bufferedReader.next().toString, requiredSchema)
     } catch {
       case e: BadRecordException =>
-        logInfo(s"Invalid record found in file '${path.toUri}': ${e.getMessage}", e)
+        logInfo(s"Invalid record found in file '${file.filePath}': ${e.getMessage}", e)
         cefOptions.mode match {
           case PermissiveMode =>
             e.partialResult() match {
@@ -53,9 +30,9 @@ final class CefDataIterator(conf: Configuration, path: Path, dataSchema: StructT
               case None => new GenericInternalRow(requiredSchema.fields.length)
             }
           case _ =>
-            logError(s"Failed to read file because of invalid record in file '${path.toUri}': ${e.getMessage}")
+            logError(s"Failed to read file because of invalid record in file '${file.filePath}': ${e.getMessage}")
             throw new SparkException(
-              s"""Invalid rows detected in ${path.toUri}. Parse mode ${FailFastMode.name}.
+              s"""Invalid rows detected in ${file.filePath}. Parse mode ${FailFastMode.name}.
                  |To process malformed records as null try setting 'mode' to 'PERMISSIVE'.""".stripMargin, e)
         }
     }

--- a/src/main/scala/com/bp/sds/cef/CefFileSource.scala
+++ b/src/main/scala/com/bp/sds/cef/CefFileSource.scala
@@ -2,10 +2,10 @@ package com.bp.sds.cef
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
-import org.apache.hadoop.mapreduce.Job
+import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.datasources.{OutputWriterFactory, PartitionedFile, TextBasedFileFormat}
+import org.apache.spark.sql.execution.datasources.{CodecStreams, OutputWriter, OutputWriterFactory, PartitionedFile, TextBasedFileFormat}
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
@@ -34,7 +34,8 @@ private[cef] class CefFileSource extends TextBasedFileFormat with DataSourceRegi
     }
   }
 
-  override def prepareWrite(sparkSession: SparkSession, job: Job, options: Map[String, String], dataSchema: StructType): OutputWriterFactory = throw new RuntimeException("No write support")
+  override def prepareWrite(sparkSession: SparkSession, job: Job, options: Map[String, String], dataSchema: StructType): OutputWriterFactory =
+    new CefOutputWriterFactory(options)
 }
 
 

--- a/src/main/scala/com/bp/sds/cef/CefFileSource.scala
+++ b/src/main/scala/com/bp/sds/cef/CefFileSource.scala
@@ -2,10 +2,10 @@ package com.bp.sds.cef
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
-import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
+import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.datasources.{CodecStreams, OutputWriter, OutputWriterFactory, PartitionedFile, TextBasedFileFormat}
+import org.apache.spark.sql.execution.datasources.{OutputWriterFactory, PartitionedFile, TextBasedFileFormat}
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
@@ -13,7 +13,8 @@ import org.apache.spark.util.SerializableConfiguration
 private[cef] class CefFileSource extends TextBasedFileFormat with DataSourceRegister {
   override def shortName(): String = "cef"
 
-  override def isSplitable(sparkSession: SparkSession, options: Map[String, String], path: Path): Boolean = false
+  override def isSplitable(sparkSession: SparkSession, options: Map[String, String], path: Path): Boolean =
+    super.isSplitable(sparkSession, options, path)
 
   override def inferSchema(sparkSession: SparkSession, options: Map[String, String], files: Seq[FileStatus]): Option[StructType] = {
     if (files.isEmpty) return None
@@ -28,9 +29,7 @@ private[cef] class CefFileSource extends TextBasedFileFormat with DataSourceRegi
       sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
 
     (file: PartitionedFile) => {
-      val path = new Path(file.filePath)
-
-      new CefDataIterator(broadcastHadoopConf.value.value, path, dataSchema, requiredSchema, CefParserOptions.from(options))
+      new CefDataIterator(broadcastHadoopConf.value.value, file, dataSchema, requiredSchema, CefParserOptions.from(options))
     }
   }
 

--- a/src/main/scala/com/bp/sds/cef/CefOutputWriter.scala
+++ b/src/main/scala/com/bp/sds/cef/CefOutputWriter.scala
@@ -1,0 +1,25 @@
+package com.bp.sds.cef
+
+import java.nio.charset.StandardCharsets
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.TaskAttemptContext
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.{CodecStreams, OutputWriter}
+import org.apache.spark.sql.types.StructType
+
+private[cef] class CefOutputWriter(path: String, cefOptions: CefParserOptions, dataSchema: StructType, context: TaskAttemptContext) extends OutputWriter with Logging {
+  private val writer = CodecStreams.createOutputStreamWriter(context, new Path(path), StandardCharsets.UTF_8)
+
+  private val gen = CefRecordWriter(dataSchema, writer, cefOptions)
+
+  override def write(row: InternalRow): Unit = {
+    gen.writeRow(row)
+    gen.writeLineEnding()
+  }
+
+  override def close(): Unit = {
+    writer.close()
+  }
+}

--- a/src/main/scala/com/bp/sds/cef/CefOutputWriterBuilder.scala
+++ b/src/main/scala/com/bp/sds/cef/CefOutputWriterBuilder.scala
@@ -1,0 +1,18 @@
+package com.bp.sds.cef
+
+import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
+import org.apache.spark.sql.connector.write.LogicalWriteInfo
+import org.apache.spark.sql.execution.datasources.v2.FileWriteBuilder
+import org.apache.spark.sql.execution.datasources.{CodecStreams, OutputWriter, OutputWriterFactory}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{DataType, StructType}
+
+private[cef] case class CefOutputWriterBuilder(paths: Seq[String],
+                                               formatName: String,
+                                               supportsDataType: DataType => Boolean,
+                                               info: LogicalWriteInfo
+                                              ) extends FileWriteBuilder(paths, formatName, supportsDataType, info) {
+  override def prepareWrite(sqlConf: SQLConf, job: Job, options: Map[String, String], dataSchema: StructType): OutputWriterFactory =
+    new CefOutputWriterFactory(options)
+}
+

--- a/src/main/scala/com/bp/sds/cef/CefOutputWriterFactory.scala
+++ b/src/main/scala/com/bp/sds/cef/CefOutputWriterFactory.scala
@@ -1,0 +1,15 @@
+package com.bp.sds.cef
+
+import org.apache.hadoop.mapreduce.TaskAttemptContext
+import org.apache.spark.sql.execution.datasources.{CodecStreams, OutputWriter, OutputWriterFactory}
+import org.apache.spark.sql.types.StructType
+
+private[cef] class CefOutputWriterFactory(options: Map[String, String]) extends OutputWriterFactory {
+  private val cefOptions = CefParserOptions.from(options)
+
+  override def getFileExtension(context: TaskAttemptContext): String =
+    ".log" + CodecStreams.getCompressionExtension(context)
+
+  override def newInstance(path: String, dataSchema: StructType, context: TaskAttemptContext): OutputWriter =
+    new CefOutputWriter(path, cefOptions, dataSchema, context)
+}

--- a/src/main/scala/com/bp/sds/cef/CefParserOptions.scala
+++ b/src/main/scala/com/bp/sds/cef/CefParserOptions.scala
@@ -17,13 +17,25 @@ import scala.collection.mutable.ArrayBuffer
  * @param corruptColumnName the name of the column to use to store corrupt data
  * @param defensiveMode     handle corrupt lines where no value is given to the final key/value pair in a line
  * @param nullValue         defines a null value string used in the source file
+ * @param dateFormat        format to use for dates when writing to CEF
  */
 case class CefParserOptions(maxRecords: Int = defaultMaxRecords,
                             pivotFields: Boolean = defaultPivotFields,
                             mode: ParseMode = defaultMode,
                             corruptColumnName: String = defaultCorruptColumnName,
                             defensiveMode: Boolean = defaultDefensiveMode,
-                            nullValue: String = defaultNullValue)
+                            nullValue: String = defaultNullValue,
+                            dateFormat: String = defaultDateFormat
+                           ) {
+  /**
+   * Is the required date format epoch milliseconds
+   *
+   * @return true if the date format is for epoch milliseconds
+   */
+  def isDateFormatInMillis: Boolean = {
+    dateFormat.compareToIgnoreCase("millis") == 0
+  }
+}
 
 private[cef] object CefParserOptions {
   val defaultMaxRecords = 10000
@@ -32,16 +44,54 @@ private[cef] object CefParserOptions {
   val defaultCorruptColumnName: String = null
   val defaultDefensiveMode = false
   val defaultNullValue = "-"
+  val defaultDateFormat = "MMM dd yyyy HH:mm:ss.SSS zzz"
 
   private val encoder = new DoubleMetaphone()
+
+  private val validDateFormats = Vector[String](
+    "millis",
+    "MMM dd yyyy HH:mm:ss",
+    "MMM dd yyyy HH:mm:ss.SSS zzz",
+    "MMM dd yyyy HH:mm:ss.SSS",
+    "MMM dd yyyy HH:mm:ss zzz",
+    "MMM dd HH:mm:ss",
+    "MMM dd HH:mm:ss.SSS zzz",
+    "MMM dd HH:mm:ss.SSS",
+    "MMM dd HH:mm:ss zzz"
+  )
 
   private val validOptions = Map[String, String](
     encoder.encode("maxRecords") -> "maxRecords",
     encoder.encode("pivotFields") -> "pivotFields",
     encoder.encode("corruptRecordColumnName") -> "corruptRecordColumnName",
     encoder.encode("defensiveMode") -> "defensiveMode",
-    encoder.encode("nullValue") -> "nullValue"
+    encoder.encode("nullValue") -> "nullValue",
+    encoder.encode("dateFormat") -> "dateFormat"
   )
+
+  /**
+   * Check to see if a user provided date format value matches one of the allowed values
+   *
+   * @param userFormat format as defined by the user
+   * @return true if the format is valid, otherwise false
+   */
+  private def isValidDateFormat(userFormat: String): Boolean = {
+    userFormat.compareToIgnoreCase("millis") == 0 || validDateFormats.exists(_.compareTo(userFormat) == 0)
+  }
+
+  /**
+   * Perform a validation on the user provided date format
+   *
+   * @param userFormat format as defined by the user
+   * @return the provided format if valid, otherwise raises an error
+   * @throws CefParserOptionsException throws when the format does not match one of the allowed values
+   */
+  private def validateDateFormat(userFormat: String): String = {
+    if (!isValidDateFormat(userFormat)) {
+      throw new CefParserOptionsException(s"Unable to parse date format '$userFormat', valid options are: ${validDateFormats.mkString(", ")}")
+    }
+    userFormat
+  }
 
   /**
    * Check user provided options for any which might be spelt incorrectly
@@ -72,11 +122,18 @@ private[cef] object CefParserOptions {
    *
    * @param options the collection of options containing possible parameter values
    * @return a [[CefParserOptions]] object
+   * @throws CefParserOptionsException if the provided options are not valid
    */
   def from(options: CaseInsensitiveStringMap): CefParserOptions = {
     findInvalidOptions(options.keySet().toSet) match {
       case Some(errors) => throw new CefParserOptionsException(s"Unable to parse all options\n${errors.mkString("\n")}")
       case _ =>
+    }
+
+    val dateFormat = if (options.containsKey("dateFormat")) {
+      validateDateFormat(options.get("dateFormat"))
+    } else {
+      defaultDateFormat
     }
 
     val parsedMode: ParseMode = ParseMode.fromString(options.getOrDefault("mode", "permissive"))
@@ -87,7 +144,8 @@ private[cef] object CefParserOptions {
       parsedMode,
       options.getOrDefault("corruptRecordColumnName", defaultCorruptColumnName),
       options.getBoolean("defensiveMode", defaultDefensiveMode),
-      options.getOrDefault("nullValue", defaultNullValue)
+      options.getOrDefault("nullValue", defaultNullValue),
+      dateFormat
     )
   }
 
@@ -96,11 +154,18 @@ private[cef] object CefParserOptions {
    *
    * @param options the collection of options containing possible parameter values
    * @return a [[CefParserOptions]] object
+   * @throws CefParserOptionsException if the provided options are not valid
    */
   def from(options: Map[String, String]): CefParserOptions = {
     findInvalidOptions(options.keySet) match {
       case Some(errors) => throw new CefParserOptionsException(s"Unable to parse all options\n${errors.mkString("\n")}")
       case _ =>
+    }
+
+    val dateFormat = if (options.keys.exists(_.compareToIgnoreCase("dateFormat") == 0)) {
+      validateDateFormat(options("dateFormat"))
+    } else {
+      defaultDateFormat
     }
 
     val parsedMode: ParseMode = ParseMode.fromString(options.getOrElse("mode", "permissive"))
@@ -111,7 +176,8 @@ private[cef] object CefParserOptions {
       parsedMode,
       options.getOrElse("corruptRecordColumnName", defaultCorruptColumnName),
       options.getOrElse("defensiveMode", defaultDefensiveMode.toString).toBoolean,
-      options.getOrElse("nullValue", defaultNullValue)
+      options.getOrElse("nullValue", defaultNullValue),
+      dateFormat
     )
   }
 }

--- a/src/main/scala/com/bp/sds/cef/CefPartitionReaderFactory.scala
+++ b/src/main/scala/com/bp/sds/cef/CefPartitionReaderFactory.scala
@@ -1,6 +1,5 @@
 package com.bp.sds.cef
 
-import org.apache.hadoop.fs.Path
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.PartitionReader
@@ -19,9 +18,7 @@ private[cef] case class CefPartitionReaderFactory(
                                                    cefOptions: CefParserOptions
                                                  ) extends FilePartitionReaderFactory {
   override def buildReader(partitionedFile: PartitionedFile): PartitionReader[InternalRow] = {
-    val path = new Path(partitionedFile.filePath)
-
-    val iterator = new CefDataIterator(broadcastConf.value.value, path, dataSchema, readDataSchema, cefOptions)
+    val iterator = new CefDataIterator(broadcastConf.value.value, partitionedFile, dataSchema, readDataSchema, cefOptions)
     val reader = new PartitionReaderFromIterator[InternalRow](iterator)
 
     new PartitionReaderWithPartitionValues(reader, readDataSchema, readPartitionSchema, partitionedFile.partitionValues)

--- a/src/main/scala/com/bp/sds/cef/CefRecordWriter.scala
+++ b/src/main/scala/com/bp/sds/cef/CefRecordWriter.scala
@@ -1,16 +1,23 @@
 package com.bp.sds.cef
 
 import java.io.OutputStreamWriter
-import java.time.ZoneId
+import java.util.TimeZone
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.TimestampFormatter
 import org.apache.spark.sql.types._
 
+/**
+ * Provides a writer implementation for writing data to the CEF format
+ *
+ * @param dataSchema schema of the data being written
+ * @param writer     a writer object
+ * @param cefOptions provided options to control how writing is performed
+ */
 private[cef] case class CefRecordWriter(dataSchema: StructType, writer: OutputStreamWriter, cefOptions: CefParserOptions) {
-  private val lineSeparator = "\r\n"
+  private val lineSeparator = System.lineSeparator()
 
-  private val mandatoryFields = Vector[String](
+  private val headerFields = Vector[String](
     "cefversion",
     "devicevendor",
     "deviceproduct",
@@ -20,37 +27,90 @@ private[cef] case class CefRecordWriter(dataSchema: StructType, writer: OutputSt
     "severity"
   )
 
-  private val timestampFormatter = TimestampFormatter("MMM dd yyyy HH:mm:ss.SSS zzz", ZoneId.of("UTC"), isParsing = false)
-  //new DateTimeFormatterBuilder().appendPattern("MMM dd yyyy HH:mm:ss.SSS zzz").toFormatter()
+  private val dateFormatIsMillis = cefOptions.isDateFormatInMillis
 
+  private val timestampFormatter = if (dateFormatIsMillis) {
+    TimestampFormatter("MMM dd yyyy HH:mm:ss.SSS zzz", TimeZone.getDefault.toZoneId, isParsing = false)
+  } else {
+    TimestampFormatter(cefOptions.dateFormat, TimeZone.getDefault.toZoneId, isParsing = false)
+  }
+
+  /**
+   * Modifies a string value to ensure it complies with the CEF standard, this is for extension values only
+   *
+   * @param value the extension value to sanitize
+   * @return a string formatted to meet CEF standards
+   */
+  private def sanitizeString(value: String): String = {
+    value.replaceAll("""\\=""", "=")
+      .replaceAll("""\\""", """\\\\""")
+      .replaceAll("=", """\\=""")
+      .replaceAll("\r\n|\r|\n", """\\n""")
+  }
+
+  /**
+   * Modifies a string value to ensure it complies with the CEF standard, this is for header values only
+   *
+   * @param value the header value to sanitize
+   * @return a string formatted to meet CEF standards
+   */
+  private def sanitizeHeaderValue(value: String): String = {
+    value.replaceAll("""\\\|""", "|")
+      .replaceAll("""\\""", """\\\\""")
+      .replaceAll("""\|""", """\\|""")
+      .replaceAll("\r\n|\r|\n", " ")
+  }
+
+  /**
+   * Write a DataFrame row to the writer object in CEF
+   *
+   * @param row an [[InternalRow]] object to write
+   */
   def writeRow(row: InternalRow): Unit = {
-    val requiredFieldCount = dataSchema.fields.count(f => mandatoryFields.contains(f.name.toLowerCase))
-    if (requiredFieldCount != mandatoryFields.length) {
+    // Validate that all of the mandatory header fields are available in the schema
+    val requiredFieldCount = dataSchema.fields.count(f => headerFields.contains(f.name.toLowerCase))
+    if (requiredFieldCount != headerFields.length) {
       throw new UnsupportedOperationException("Row data must contain required CEF fields")
     }
 
-    val mandatoryFieldsBuffer = new Array[String](requiredFieldCount)
+    // Split the schema fields into header and extension fields
+    val headerFieldsBuffer = new Array[String](requiredFieldCount)
     val extensionFieldsBuffer = new Array[String](dataSchema.fields.length - requiredFieldCount)
 
+    // Write each field in the row to the output writer
     var i = 0
     while (i < row.numFields) {
       val field = dataSchema.fields(i)
-      val mandatory = mandatoryFields.contains(field.name.toLowerCase)
+      val isHeader = headerFields.contains(field.name.toLowerCase)
 
-      if (mandatory && row.isNullAt(i)) {
+      if (isHeader && row.isNullAt(i)) {
+        // If the current field is a header field and contains a null value then the current record is invalid
         throw new UnsupportedOperationException("Mandatory fields cannot contain null values")
-      } else if (mandatory) {
-        mandatoryFieldsBuffer(mandatoryFields.indexOf(field.name.toLowerCase)) = row.getString(i)
+      } else if (isHeader) {
+        // Otherwise we can write the header field to the output writer
+        headerFieldsBuffer(headerFields.indexOf(field.name.toLowerCase)) = sanitizeHeaderValue(row.getString(i))
       } else if (row.isNullAt(i)) {
+        // Where the current field is an extension field and has a null value then output using the user definable
+        // null value
         extensionFieldsBuffer(i - requiredFieldCount) = s"${field.name}=${cefOptions.nullValue}"
       } else {
+        // Otherwise, write out the extension field, converting the current value into a string representation
+        //
+        // Where the field is a timestamp the output using the user definable date format. If it is a string then
+        // output a sanitized version of the string
+        //
+        // Where the data type is not supported then write a null value
         val fieldValue = field.dataType match {
           case IntegerType => row.getInt(i).toString
           case LongType => row.getLong(i).toString
           case FloatType => row.getFloat(i).toString
           case DoubleType => row.getDouble(i).toString
-          case TimestampType => timestampFormatter.format(row.getLong(i)) // TODO: Change this to take a custom format or to use epoch seconds
-          case StringType => row.getString(i).replaceAll("""\\=""", "=").replace("=", """\=""")
+          case TimestampType => if (dateFormatIsMillis) {
+            row.getLong(i).toString
+          } else {
+            timestampFormatter.format(row.getLong(i))
+          }
+          case StringType => sanitizeString(row.getString(i))
           case _ => cefOptions.nullValue
         }
         extensionFieldsBuffer(i - requiredFieldCount) = s"${field.name}=$fieldValue"
@@ -59,14 +119,23 @@ private[cef] case class CefRecordWriter(dataSchema: StructType, writer: OutputSt
       i += 1
     }
 
+    // Combine the header fields and extension fields back together. This ensures that the header fields are listed
+    // first and in the correct order. Also, as the headers are pipe separated, but extension fields are space separated
+    // this allows the two formats to be specified.
+    //
+    // This leaves us with two fields, one pipe separated and the other space separated, these can then be joined using
+    // a final pipe
     val combinedFields = Seq(
-      mandatoryFieldsBuffer.mkString("|"),
+      headerFieldsBuffer.mkString("|"),
       extensionFieldsBuffer.mkString(" ")
     )
 
     writer.write(combinedFields.mkString("|"))
   }
 
+  /**
+   * Write a line ending to the output writer
+   */
   def writeLineEnding(): Unit = {
     writer.write(lineSeparator)
   }

--- a/src/main/scala/com/bp/sds/cef/CefRecordWriter.scala
+++ b/src/main/scala/com/bp/sds/cef/CefRecordWriter.scala
@@ -1,0 +1,73 @@
+package com.bp.sds.cef
+
+import java.io.OutputStreamWriter
+import java.time.ZoneId
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.TimestampFormatter
+import org.apache.spark.sql.types._
+
+private[cef] case class CefRecordWriter(dataSchema: StructType, writer: OutputStreamWriter, cefOptions: CefParserOptions) {
+  private val lineSeparator = "\r\n"
+
+  private val mandatoryFields = Vector[String](
+    "cefversion",
+    "devicevendor",
+    "deviceproduct",
+    "deviceversion",
+    "signatureid",
+    "name",
+    "severity"
+  )
+
+  private val timestampFormatter = TimestampFormatter("MMM dd yyyy HH:mm:ss.SSS zzz", ZoneId.of("UTC"), isParsing = false)
+  //new DateTimeFormatterBuilder().appendPattern("MMM dd yyyy HH:mm:ss.SSS zzz").toFormatter()
+
+  def writeRow(row: InternalRow): Unit = {
+    val requiredFieldCount = dataSchema.fields.count(f => mandatoryFields.contains(f.name.toLowerCase))
+    if (requiredFieldCount != mandatoryFields.length) {
+      throw new UnsupportedOperationException("Row data must contain required CEF fields")
+    }
+
+    val mandatoryFieldsBuffer = new Array[String](requiredFieldCount)
+    val extensionFieldsBuffer = new Array[String](dataSchema.fields.length - requiredFieldCount)
+
+    var i = 0
+    while (i < row.numFields) {
+      val field = dataSchema.fields(i)
+      val mandatory = mandatoryFields.contains(field.name.toLowerCase)
+
+      if (mandatory && row.isNullAt(i)) {
+        throw new UnsupportedOperationException("Mandatory fields cannot contain null values")
+      } else if (mandatory) {
+        mandatoryFieldsBuffer(mandatoryFields.indexOf(field.name.toLowerCase)) = row.getString(i)
+      } else if (row.isNullAt(i)) {
+        extensionFieldsBuffer(i - requiredFieldCount) = s"${field.name}=${cefOptions.nullValue}"
+      } else {
+        val fieldValue = field.dataType match {
+          case IntegerType => row.getInt(i).toString
+          case LongType => row.getLong(i).toString
+          case FloatType => row.getFloat(i).toString
+          case DoubleType => row.getDouble(i).toString
+          case TimestampType => timestampFormatter.format(row.getLong(i)) // TODO: Change this to take a custom format or to use epoch seconds
+          case StringType => row.getString(i).replaceAll("""\\=""", "=").replace("=", """\=""")
+          case _ => cefOptions.nullValue
+        }
+        extensionFieldsBuffer(i - requiredFieldCount) = s"${field.name}=$fieldValue"
+      }
+
+      i += 1
+    }
+
+    val combinedFields = Seq(
+      mandatoryFieldsBuffer.mkString("|"),
+      extensionFieldsBuffer.mkString(" ")
+    )
+
+    writer.write(combinedFields.mkString("|"))
+  }
+
+  def writeLineEnding(): Unit = {
+    writer.write(lineSeparator)
+  }
+}

--- a/src/main/scala/com/bp/sds/cef/CefScan.scala
+++ b/src/main/scala/com/bp/sds/cef/CefScan.scala
@@ -25,7 +25,7 @@ private[cef] case class CefScan(
   private val optionsAsScala = options.asScala.toMap
   private val cefOptions = CefParserOptions.from(options)
 
-  override def isSplitable(path: Path): Boolean = false
+  override def isSplitable(path: Path): Boolean = super.isSplitable(path)
 
   override def withFilters(partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): FileScan =
     this.copy(partitionFilters = partitionFilters, dataFilters = dataFilters)

--- a/src/main/scala/com/bp/sds/cef/CefTable.scala
+++ b/src/main/scala/com/bp/sds/cef/CefTable.scala
@@ -41,9 +41,16 @@ private[cef] class CefTable(
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder =
     CefScanBuilder(sparkSession, fileIndex, schema, dataSchema, options)
 
-  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = throw new RuntimeException("No write support")
+  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder =
+    CefOutputWriterBuilder(paths, formatName, supportsDataType, info)
 
   override def name(): String = name
 
   override def fallbackFileFormat: Class[_ <: FileFormat] = classOf[CefFileSource]
 }
+
+
+
+
+
+

--- a/src/main/scala/com/bp/sds/cef/CefTable.scala
+++ b/src/main/scala/com/bp/sds/cef/CefTable.scala
@@ -48,9 +48,3 @@ private[cef] class CefTable(
 
   override def fallbackFileFormat: Class[_ <: FileFormat] = classOf[CefFileSource]
 }
-
-
-
-
-
-

--- a/src/main/scala/com/bp/sds/cef/package.scala
+++ b/src/main/scala/com/bp/sds/cef/package.scala
@@ -1,11 +1,15 @@
 package com.bp.sds
 
-import org.apache.spark.sql.{DataFrame, DataFrameReader}
+import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter}
 
 package object cef {
   implicit class CefDataFrameReader(val reader: DataFrameReader) extends AnyVal {
     def cef(path: String): DataFrame = reader.format("com.bp.sds.cef").load(path)
 
     def cef(paths: String*): DataFrame = reader.format("com.bp.sds.cef").load(paths:_*)
+  }
+
+  implicit class CefDataFrameWriter[T](val writer: DataFrameWriter[T]) extends AnyVal {
+    def cef: String => Unit = writer.format("com.bp.sds.cef").save
   }
 }

--- a/src/test/resources/cef-records/writer-expected/simple-writer.log
+++ b/src/test/resources/cef-records/writer-expected/simple-writer.log
@@ -1,0 +1,20 @@
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 0\=true cs1Label=Some label cs2=- cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 1\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 2\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 3\=true cs1Label=Some label cs2=- cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 4\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 5\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 6\=true cs1Label=Some label cs2=- cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 7\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 8\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 9\=true cs1Label=Some label cs2=- cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 10\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 11\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 12\=true cs1Label=Some label cs2=- cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 13\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 14\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 15\=true cs1Label=Some label cs2=- cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 16\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 17\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 18\=true cs1Label=Some label cs2=- cs2Label=Another label rt=1595194698000000
+CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing|3|cs1=This is a sample record where 19\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000000

--- a/src/test/scala/com/bp/sds/cef/CefDataFrameReaderTests.scala
+++ b/src/test/scala/com/bp/sds/cef/CefDataFrameReaderTests.scala
@@ -14,7 +14,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class CefDataSourceTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+class CefDataFrameReaderTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
 
   lazy val spark: SparkSession = SparkSession.builder()

--- a/src/test/scala/com/bp/sds/cef/CefDataFrameWriterTests.scala
+++ b/src/test/scala/com/bp/sds/cef/CefDataFrameWriterTests.scala
@@ -119,6 +119,268 @@ class CefDataFrameWriterTests extends AnyFlatSpec with Matchers with BeforeAndAf
     unsupportedOperationException.count(_.getMessage.endsWith("Mandatory fields cannot contain null values")) should be(1)
   }
 
+  behavior of "Writing a DataFrame with date formats"
+
+  it should "default to writing with year, milliseconds, and timezone" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", TimestampType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
+    ).asJava
+
+    val outputPath = s"$outputLocation/timestamps-default.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 2020 10:17:31.964 UTC")
+  }
+
+  it should "support writing with MMM dd yyyy HH:mm:ss" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", TimestampType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
+    ).asJava
+
+    val outputPath = s"$outputLocation/timestamps-default.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .option("dateFormat", "MMM dd yyyy HH:mm:ss")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 2020 10:17:31")
+  }
+
+  it should "support writing with MMM dd yyyy HH:mm:ss.SSS" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", TimestampType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
+    ).asJava
+
+    val outputPath = s"$outputLocation/timestamps-default.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .option("dateFormat", "MMM dd yyyy HH:mm:ss.SSS")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 2020 10:17:31.964")
+  }
+
+  it should "support writing with MMM dd yyyy HH:mm:ss zzz" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", TimestampType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
+    ).asJava
+
+    val outputPath = s"$outputLocation/timestamps-default.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .option("dateFormat", "MMM dd yyyy HH:mm:ss zzz")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 2020 10:17:31 UTC")
+  }
+
+  it should "support writing with MMM dd HH:mm:ss" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", TimestampType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
+    ).asJava
+
+    val outputPath = s"$outputLocation/timestamps-default.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .option("dateFormat", "MMM dd HH:mm:ss")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 10:17:31")
+  }
+
+  it should "support writing with MMM dd HH:mm:ss.SSS zzz" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", TimestampType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
+    ).asJava
+
+    val outputPath = s"$outputLocation/timestamps-default.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .option("dateFormat", "MMM dd HH:mm:ss.SSS zzz")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 10:17:31.964 UTC")
+  }
+
+  it should "support writing with MMM dd HH:mm:ss.SSS" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", TimestampType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
+    ).asJava
+
+    val outputPath = s"$outputLocation/timestamps-default.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .option("dateFormat", "MMM dd HH:mm:ss.SSS")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 10:17:31.964")
+  }
+
+  it should "support writing with MMM dd HH:mm:ss zzz" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", TimestampType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
+    ).asJava
+
+    val outputPath = s"$outputLocation/timestamps-default.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .option("dateFormat", "MMM dd HH:mm:ss zzz")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 10:17:31 UTC")
+  }
+
+  it should "support writing with millis" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", TimestampType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
+    ).asJava
+
+    val outputPath = s"$outputLocation/timestamps-default.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .option("dateFormat", "millis")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=1602757051964000")
+  }
+
   behavior of "Writing a DataFrame with valid data"
 
   it should "write a record out to file with mandatory fields in the correct order" in {
@@ -207,6 +469,73 @@ class CefDataFrameWriterTests extends AnyFlatSpec with Matchers with BeforeAndAf
     val content = getFileContent(outputPath)
 
     content should be("""cefversion|vendor|product|version|sigid|name|sev|cs1=Issue from ip\=127.0.0.01 signature\=abc123\=\=""")
+  }
+
+  it should "write a record out to file handling multi-line strings" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", StringType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev",
+        """This
+          |is
+          |a
+          |multiline \ value
+          |
+          |string
+          |which=bad""".stripMargin)
+    ).asJava
+
+    val outputPath = s"$outputLocation/eescaped-symbols.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("""cefversion|vendor|product|version|sigid|name|sev|cs1=This\nis\na\nmultiline \\ value\n\nstring\nwhich\=bad""")
+  }
+
+  it should "write a record out to file handling multi-line and pipe values in header strings" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", StringType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion | id", """vendor \ id""", "product", "version", "sigid", "name",
+        """sev
+          |id
+          |3""".stripMargin,
+        "Value")
+    ).asJava
+
+    val outputPath = s"$outputLocation/eescaped-symbols.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("""cefversion \| id|vendor \\ id|product|version|sigid|name|sev id 3|cs1=Value""")
   }
 
   it should "validate mandatory fields regardless of case" in {

--- a/src/test/scala/com/bp/sds/cef/CefDataFrameWriterTests.scala
+++ b/src/test/scala/com/bp/sds/cef/CefDataFrameWriterTests.scala
@@ -98,7 +98,7 @@ class CefDataFrameWriterTests extends AnyFlatSpec with Matchers with BeforeAndAf
 
   behavior of "Writing a DataFrame to CEF"
 
-  it should "write out data in the expected CEC file format" in {
+  it should "write out data in the expected CEF file format" in {
     val schema = StructType(Array(
       StructField("CEFVersion", StringType, nullable = true),
       StructField("DeviceVendor", StringType, nullable = true),

--- a/src/test/scala/com/bp/sds/cef/CefDataFrameWriterTests.scala
+++ b/src/test/scala/com/bp/sds/cef/CefDataFrameWriterTests.scala
@@ -1,0 +1,266 @@
+package com.bp.sds.cef
+
+import java.io.File
+import java.sql.Timestamp
+import java.util.TimeZone
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Row, SparkSession}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters.seqAsJavaListConverter
+import scala.io.Source
+
+class CefDataFrameWriterTests extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+  TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+
+  lazy val projectRootFile: File = new File(".").getAbsoluteFile.getParentFile
+  lazy val projectRoot: String = projectRootFile.toString
+
+  private val outputLocation = s"$projectRoot${File.separatorChar}test-output"
+
+  def deleteRecursively(file: File): Unit = {
+    if (!file.exists()) return
+
+    file match {
+      case f if f.isDirectory =>
+        f.listFiles().foreach(deleteRecursively)
+        f.delete()
+      case _ => file.delete()
+    }
+  }
+
+  lazy val spark: SparkSession = SparkSession.builder()
+    .appName("data-source-tests")
+    .master("local[2]")
+    .getOrCreate()
+
+  override def beforeAll(): Unit = {
+    deleteRecursively(new File(outputLocation))
+  }
+
+  override def afterAll(): Unit = {
+    spark.close()
+
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
+
+    deleteRecursively(new File(outputLocation))
+  }
+
+  private def getNestedCauses(exception: Throwable): Seq[Throwable] = {
+    if (exception.getCause != null) {
+      Seq(exception) ++ getNestedCauses(exception.getCause)
+    } else {
+      Seq(exception)
+    }
+  }
+
+  private def getFileContent(path: String, ext: String = ".log"): String = {
+    val outputPathFile = new File(path)
+    val partFile = outputPathFile.listFiles().filter(_.getName.endsWith(ext)).head
+    val partFileSource = Source.fromFile(partFile)
+    val content = partFileSource.getLines().mkString("\n")
+    partFileSource.close()
+
+    content
+  }
+
+  behavior of "Writing a DataFrame to CEF with invalid configuration"
+
+  it should "raise an error if the mandatory fields are not provided" in {
+    // Leave out CEFVersion
+    val schema = StructType(Array(
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("vendor", "product", "version", "sigid", "name", "sev")
+    ).asJava
+
+    val df = spark.createDataFrame(data, schema)
+
+    val exception = the[SparkException] thrownBy df.write.mode("overwrite").cef(s"$outputLocation/missing-mandatory.log")
+    val unsupportedOperationException = getNestedCauses(exception).filter(_.isInstanceOf[UnsupportedOperationException])
+
+    unsupportedOperationException.length should be >= 1
+    unsupportedOperationException.count(_.getMessage.endsWith("Row data must contain required CEF fields")) should be(1)
+  }
+
+  it should "raise an error if the mandatory fields contain null values" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", null, "name", "sev")
+    ).asJava
+
+    val df = spark.createDataFrame(data, schema)
+
+    val exception = the[SparkException] thrownBy df.write.mode("overwrite").cef(s"$outputLocation/null-mandatory.log")
+    val unsupportedOperationException = getNestedCauses(exception).filter(_.isInstanceOf[UnsupportedOperationException])
+
+    unsupportedOperationException.length should be >= 1
+    unsupportedOperationException.count(_.getMessage.endsWith("Mandatory fields cannot contain null values")) should be(1)
+  }
+
+  behavior of "Writing a DataFrame with valid data"
+
+  it should "write a record out to file with mandatory fields in the correct order" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", StringType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", "cs1value")
+    ).asJava
+
+    val outputPath = s"$outputLocation/expected-order.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=cs1value")
+  }
+
+  it should "write a record out to file with properly converted values" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("rt", TimestampType, nullable = true),
+      StructField("cs1", IntegerType, nullable = true),
+      StructField("cs2", LongType, nullable = true),
+      StructField("cs3", FloatType, nullable = true),
+      StructField("cs4", DoubleType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"), 123, 1234567890L, 1.234F, 3.1415D)
+    ).asJava
+
+    val outputPath = s"$outputLocation/value-types-check.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("cefversion|vendor|product|version|sigid|name|sev|rt=Oct 15 2020 10:17:31.964 UTC cs1=123 cs2=1234567890 cs3=1.234 cs4=3.1415")
+  }
+
+  it should "write a record out to file with additional equality signs escaped" in {
+    val schema = StructType(Array(
+      StructField("CEFVersion", StringType, nullable = true),
+      StructField("DeviceVendor", StringType, nullable = true),
+      StructField("DeviceProduct", StringType, nullable = true),
+      StructField("DeviceVersion", StringType, nullable = true),
+      StructField("SignatureID", StringType, nullable = true),
+      StructField("Name", StringType, nullable = true),
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", StringType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", "Issue from ip=127.0.0.01 signature=abc123==")
+    ).asJava
+
+    val outputPath = s"$outputLocation/eescaped-symbols.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("""cefversion|vendor|product|version|sigid|name|sev|cs1=Issue from ip\=127.0.0.01 signature\=abc123\=\=""")
+  }
+
+  it should "validate mandatory fields regardless of case" in {
+    val schema = StructType(Array(
+      StructField("cefversion", StringType, nullable = true),
+      StructField("devicevendor", StringType, nullable = true),
+      StructField("deviceproduct", StringType, nullable = true),
+      StructField("deviceversion", StringType, nullable = true),
+      StructField("signatureid", StringType, nullable = true),
+      StructField("name", StringType, nullable = true),
+      StructField("severity", StringType, nullable = true),
+      StructField("cs1", StringType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", "cs1value")
+    ).asJava
+
+    val outputPath = s"$outputLocation/mandatory-case-check.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .cef(outputPath)
+
+    succeed
+  }
+
+  it should "write out null values based on user specified value" in {
+    val schema = StructType(Array(
+      StructField("cefversion", StringType, nullable = true),
+      StructField("devicevendor", StringType, nullable = true),
+      StructField("deviceproduct", StringType, nullable = true),
+      StructField("deviceversion", StringType, nullable = true),
+      StructField("signatureid", StringType, nullable = true),
+      StructField("name", StringType, nullable = true),
+      StructField("severity", StringType, nullable = true),
+      StructField("cs1", StringType, nullable = true)
+    ))
+
+    val data = Seq(
+      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", null)
+    ).asJava
+
+    val outputPath = s"$outputLocation/null-value-check.log"
+
+    spark.createDataFrame(data, schema)
+      .write
+      .mode("overwrite")
+      .option("nullValue", "NA")
+      .cef(outputPath)
+
+    val content = getFileContent(outputPath)
+
+    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=NA")
+  }
+}

--- a/src/test/scala/com/bp/sds/cef/CefDataFrameWriterTests.scala
+++ b/src/test/scala/com/bp/sds/cef/CefDataFrameWriterTests.scala
@@ -93,7 +93,7 @@ class CefDataFrameWriterTests extends AnyFlatSpec with Matchers with BeforeAndAf
     val unsupportedOperationException = getNestedCauses(exception).filter(_.isInstanceOf[UnsupportedOperationException])
 
     unsupportedOperationException.length should be >= 1
-    unsupportedOperationException.count(_.getMessage.endsWith("Row data must contain required CEF fields")) should be(1)
+    unsupportedOperationException.count(_.getMessage.contains("Schema must contain required CEF fields")) should be(1)
   }
 
   behavior of "Writing a DataFrame to CEF"

--- a/src/test/scala/com/bp/sds/cef/CefDataFrameWriterTests.scala
+++ b/src/test/scala/com/bp/sds/cef/CefDataFrameWriterTests.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.sql.Timestamp
 import java.util.TimeZone
 
+import com.bp.sds.cef.utils.ResourceFileUtils
 import org.apache.spark.SparkException
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SparkSession}
@@ -95,7 +96,9 @@ class CefDataFrameWriterTests extends AnyFlatSpec with Matchers with BeforeAndAf
     unsupportedOperationException.count(_.getMessage.endsWith("Row data must contain required CEF fields")) should be(1)
   }
 
-  it should "raise an error if the mandatory fields contain null values" in {
+  behavior of "Writing a DataFrame to CEF"
+
+  it should "write out data in the expected CEC file format" in {
     val schema = StructType(Array(
       StructField("CEFVersion", StringType, nullable = true),
       StructField("DeviceVendor", StringType, nullable = true),
@@ -103,493 +106,46 @@ class CefDataFrameWriterTests extends AnyFlatSpec with Matchers with BeforeAndAf
       StructField("DeviceVersion", StringType, nullable = true),
       StructField("SignatureID", StringType, nullable = true),
       StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true)
+      StructField("Severity", StringType, nullable = true),
+      StructField("cs1", StringType, nullable = true),
+      StructField("cs1Label", StringType, nullable = true),
+      StructField("cs2", StringType, nullable = true),
+      StructField("cs2Label", StringType, nullable = true),
+      StructField("rt", TimestampType, nullable = true)
     ))
 
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", null, "name", "sev")
-    ).asJava
+    //CEF:0|Testing|DataFrame \| Writer|1|1|Test Writing
+    //cs1=This is a sample record where 0\=true cs1Label=Some label cs2=A value with | values cs2Label=Another label rt=1595194698000
+
+    val data = 0.until(20).map { i =>
+      Row(
+        "CEF:0",
+        "Testing",
+        "DataFrame | Writer",
+        "1",
+        "1",
+        "Test Writing",
+        "3",
+        s"This is a sample record where $i=true",
+        "Some label",
+        if (i % 3 == 0) {
+          null
+        } else {
+          "A value with | values"
+        },
+        "Another label",
+        Timestamp.valueOf("2020-07-19 21:38:18.000000")
+      )
+    }.asJava
+
+    val outputPath = s"$outputLocation/simple-writer.log"
+    val expectedContent = ResourceFileUtils.getFileContent("/cef-records/writer-expected/simple-writer.log")
 
     val df = spark.createDataFrame(data, schema)
+    df.coalesce(1).write.mode("overwrite").option("dateFormat", "millis").cef(outputPath)
 
-    val exception = the[SparkException] thrownBy df.write.mode("overwrite").cef(s"$outputLocation/null-mandatory.log")
-    val unsupportedOperationException = getNestedCauses(exception).filter(_.isInstanceOf[UnsupportedOperationException])
+    val writtenContent = getFileContent(outputPath)
 
-    unsupportedOperationException.length should be >= 1
-    unsupportedOperationException.count(_.getMessage.endsWith("Mandatory fields cannot contain null values")) should be(1)
-  }
-
-  behavior of "Writing a DataFrame with date formats"
-
-  it should "default to writing with year, milliseconds, and timezone" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", TimestampType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
-    ).asJava
-
-    val outputPath = s"$outputLocation/timestamps-default.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 2020 10:17:31.964 UTC")
-  }
-
-  it should "support writing with MMM dd yyyy HH:mm:ss" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", TimestampType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
-    ).asJava
-
-    val outputPath = s"$outputLocation/timestamps-default.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .option("dateFormat", "MMM dd yyyy HH:mm:ss")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 2020 10:17:31")
-  }
-
-  it should "support writing with MMM dd yyyy HH:mm:ss.SSS" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", TimestampType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
-    ).asJava
-
-    val outputPath = s"$outputLocation/timestamps-default.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .option("dateFormat", "MMM dd yyyy HH:mm:ss.SSS")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 2020 10:17:31.964")
-  }
-
-  it should "support writing with MMM dd yyyy HH:mm:ss zzz" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", TimestampType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
-    ).asJava
-
-    val outputPath = s"$outputLocation/timestamps-default.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .option("dateFormat", "MMM dd yyyy HH:mm:ss zzz")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 2020 10:17:31 UTC")
-  }
-
-  it should "support writing with MMM dd HH:mm:ss" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", TimestampType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
-    ).asJava
-
-    val outputPath = s"$outputLocation/timestamps-default.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .option("dateFormat", "MMM dd HH:mm:ss")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 10:17:31")
-  }
-
-  it should "support writing with MMM dd HH:mm:ss.SSS zzz" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", TimestampType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
-    ).asJava
-
-    val outputPath = s"$outputLocation/timestamps-default.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .option("dateFormat", "MMM dd HH:mm:ss.SSS zzz")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 10:17:31.964 UTC")
-  }
-
-  it should "support writing with MMM dd HH:mm:ss.SSS" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", TimestampType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
-    ).asJava
-
-    val outputPath = s"$outputLocation/timestamps-default.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .option("dateFormat", "MMM dd HH:mm:ss.SSS")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 10:17:31.964")
-  }
-
-  it should "support writing with MMM dd HH:mm:ss zzz" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", TimestampType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
-    ).asJava
-
-    val outputPath = s"$outputLocation/timestamps-default.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .option("dateFormat", "MMM dd HH:mm:ss zzz")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=Oct 15 10:17:31 UTC")
-  }
-
-  it should "support writing with millis" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", TimestampType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"))
-    ).asJava
-
-    val outputPath = s"$outputLocation/timestamps-default.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .option("dateFormat", "millis")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=1602757051964000")
-  }
-
-  behavior of "Writing a DataFrame with valid data"
-
-  it should "write a record out to file with mandatory fields in the correct order" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", StringType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", "cs1value")
-    ).asJava
-
-    val outputPath = s"$outputLocation/expected-order.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=cs1value")
-  }
-
-  it should "write a record out to file with properly converted values" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("rt", TimestampType, nullable = true),
-      StructField("cs1", IntegerType, nullable = true),
-      StructField("cs2", LongType, nullable = true),
-      StructField("cs3", FloatType, nullable = true),
-      StructField("cs4", DoubleType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", Timestamp.valueOf("2020-10-15 10:17:31.964"), 123, 1234567890L, 1.234F, 3.1415D)
-    ).asJava
-
-    val outputPath = s"$outputLocation/value-types-check.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("cefversion|vendor|product|version|sigid|name|sev|rt=Oct 15 2020 10:17:31.964 UTC cs1=123 cs2=1234567890 cs3=1.234 cs4=3.1415")
-  }
-
-  it should "write a record out to file with additional equality signs escaped" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", StringType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", "Issue from ip=127.0.0.01 signature=abc123==")
-    ).asJava
-
-    val outputPath = s"$outputLocation/eescaped-symbols.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("""cefversion|vendor|product|version|sigid|name|sev|cs1=Issue from ip\=127.0.0.01 signature\=abc123\=\=""")
-  }
-
-  it should "write a record out to file handling multi-line strings" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", StringType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev",
-        """This
-          |is
-          |a
-          |multiline \ value
-          |
-          |string
-          |which=bad""".stripMargin)
-    ).asJava
-
-    val outputPath = s"$outputLocation/eescaped-symbols.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("""cefversion|vendor|product|version|sigid|name|sev|cs1=This\nis\na\nmultiline \\ value\n\nstring\nwhich\=bad""")
-  }
-
-  it should "write a record out to file handling multi-line and pipe values in header strings" in {
-    val schema = StructType(Array(
-      StructField("CEFVersion", StringType, nullable = true),
-      StructField("DeviceVendor", StringType, nullable = true),
-      StructField("DeviceProduct", StringType, nullable = true),
-      StructField("DeviceVersion", StringType, nullable = true),
-      StructField("SignatureID", StringType, nullable = true),
-      StructField("Name", StringType, nullable = true),
-      StructField("Severity", StringType, nullable = true),
-      StructField("cs1", StringType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion | id", """vendor \ id""", "product", "version", "sigid", "name",
-        """sev
-          |id
-          |3""".stripMargin,
-        "Value")
-    ).asJava
-
-    val outputPath = s"$outputLocation/eescaped-symbols.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("""cefversion \| id|vendor \\ id|product|version|sigid|name|sev id 3|cs1=Value""")
-  }
-
-  it should "validate mandatory fields regardless of case" in {
-    val schema = StructType(Array(
-      StructField("cefversion", StringType, nullable = true),
-      StructField("devicevendor", StringType, nullable = true),
-      StructField("deviceproduct", StringType, nullable = true),
-      StructField("deviceversion", StringType, nullable = true),
-      StructField("signatureid", StringType, nullable = true),
-      StructField("name", StringType, nullable = true),
-      StructField("severity", StringType, nullable = true),
-      StructField("cs1", StringType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", "cs1value")
-    ).asJava
-
-    val outputPath = s"$outputLocation/mandatory-case-check.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .cef(outputPath)
-
-    succeed
-  }
-
-  it should "write out null values based on user specified value" in {
-    val schema = StructType(Array(
-      StructField("cefversion", StringType, nullable = true),
-      StructField("devicevendor", StringType, nullable = true),
-      StructField("deviceproduct", StringType, nullable = true),
-      StructField("deviceversion", StringType, nullable = true),
-      StructField("signatureid", StringType, nullable = true),
-      StructField("name", StringType, nullable = true),
-      StructField("severity", StringType, nullable = true),
-      StructField("cs1", StringType, nullable = true)
-    ))
-
-    val data = Seq(
-      Row("cefversion", "vendor", "product", "version", "sigid", "name", "sev", null)
-    ).asJava
-
-    val outputPath = s"$outputLocation/null-value-check.log"
-
-    spark.createDataFrame(data, schema)
-      .write
-      .mode("overwrite")
-      .option("nullValue", "NA")
-      .cef(outputPath)
-
-    val content = getFileContent(outputPath)
-
-    content should be("cefversion|vendor|product|version|sigid|name|sev|cs1=NA")
+    writtenContent should be(expectedContent)
   }
 }

--- a/src/test/scala/com/bp/sds/cef/CefParserOptionsTests.scala
+++ b/src/test/scala/com/bp/sds/cef/CefParserOptionsTests.scala
@@ -15,7 +15,8 @@ class CefParserOptionsTests extends AnyFlatSpec with Matchers {
       "pivotFields" -> "true",
       "corruptRecordColumnName" -> "test_col",
       "defensiveMode" -> "true",
-      "nullValue" -> "NA"
+      "nullValue" -> "NA",
+      "dateFormat" -> "millis"
     )
 
     val parserOptions = CefParserOptions.from(inputMap)
@@ -25,6 +26,7 @@ class CefParserOptionsTests extends AnyFlatSpec with Matchers {
     parserOptions.corruptColumnName should be("test_col")
     parserOptions.defensiveMode should be(true)
     parserOptions.nullValue should be("NA")
+    parserOptions.dateFormat should be("millis")
   }
 
   it should "provide default options when values are not provided" in {
@@ -35,6 +37,7 @@ class CefParserOptionsTests extends AnyFlatSpec with Matchers {
     parserOptions.corruptColumnName shouldBe null
     parserOptions.defensiveMode should be(false)
     parserOptions.nullValue should be("-")
+    parserOptions.dateFormat should be("MMM dd yyyy HH:mm:ss.SSS zzz")
   }
 
   it should "show a helpful error if the specified keys are not spelt correctly" in {
@@ -43,7 +46,8 @@ class CefParserOptionsTests extends AnyFlatSpec with Matchers {
       "pivotFeilds" -> "true",
       "coruptRecordColumName" -> "test_col",
       "devensiveMoad" -> "true",
-      "nulVal" -> "NA"
+      "nulVal" -> "NA",
+      "datfrmt" -> "millis"
     )
 
     val exception = the[CefParserOptionsException] thrownBy CefParserOptions.from(inputMap)
@@ -52,6 +56,17 @@ class CefParserOptionsTests extends AnyFlatSpec with Matchers {
     exception.getMessage.contains("Unable to find option 'coruptRecordColumName', did you mean 'corruptRecordColumnName'") should be(true)
     exception.getMessage.contains("Unable to find option 'devensiveMoad', did you mean 'defensiveMode'") should be(true)
     exception.getMessage.contains("Unable to find option 'nulVal', did you mean 'nullValue'") should be(true)
+    exception.getMessage.contains("Unable to find option 'datfrmt', did you mean 'dateFormat'") should be(true)
+  }
+
+  it should "throw an error if an invalid date format is provided" in {
+    val inputMap = Map[String, String](
+      "dateFormat" -> "yyyy-MM-dd HH:mm:ss.SSS zzz"
+    )
+
+    val exception = the[CefParserOptionsException] thrownBy CefParserOptions.from(inputMap)
+
+    exception.getMessage.contains("Unable to parse date format 'yyyy-MM-dd HH:mm:ss.SSS zzz', valid options are") should be(true)
   }
 
   behavior of "Parsing a string map"
@@ -62,7 +77,8 @@ class CefParserOptionsTests extends AnyFlatSpec with Matchers {
       "pivotFields" -> "true",
       "corruptRecordColumnName" -> "test_col",
       "defensiveMode" -> "true",
-      "nullValue" -> "NA"
+      "nullValue" -> "NA",
+      "dateFormat" -> "millis"
     )
 
     val inputMap = new CaseInsensitiveStringMap(originalMap.asJava)
@@ -74,6 +90,7 @@ class CefParserOptionsTests extends AnyFlatSpec with Matchers {
     parserOptions.corruptColumnName should be("test_col")
     parserOptions.defensiveMode should be(true)
     parserOptions.nullValue should be("NA")
+    parserOptions.dateFormat should be("millis")
   }
 
   it should "provide default options when values are not provided" in {
@@ -85,6 +102,7 @@ class CefParserOptionsTests extends AnyFlatSpec with Matchers {
     parserOptions.corruptColumnName shouldBe null
     parserOptions.defensiveMode should be(false)
     parserOptions.nullValue should be("-")
+    parserOptions.dateFormat should be("MMM dd yyyy HH:mm:ss.SSS zzz")
   }
 
   it should "show a helpful error if the specified keys are not spelt correctly" in {
@@ -93,17 +111,30 @@ class CefParserOptionsTests extends AnyFlatSpec with Matchers {
       "pivotFeilds" -> "true",
       "coruptRecordColumName" -> "test_col",
       "devensiveMoad" -> "true",
-      "nulVal" -> "NA"
+      "nulVal" -> "NA",
+      "datfrmt" -> "millis"
     )
 
     val inputMap = new CaseInsensitiveStringMap(originalMap.asJava)
 
     val exception = the[CefParserOptionsException] thrownBy CefParserOptions.from(inputMap)
-    println(exception.getMessage)
     exception.getMessage.contains("Unable to find option 'macsrexord', did you mean 'maxRecords") should be(true)
     exception.getMessage.contains("Unable to find option 'pivotfeilds', did you mean 'pivotFields") should be(true)
     exception.getMessage.contains("Unable to find option 'coruptrecordcolumname', did you mean 'corruptRecordColumnName") should be(true)
     exception.getMessage.contains("Unable to find option 'devensivemoad', did you mean 'defensiveMode'") should be(true)
     exception.getMessage.contains("Unable to find option 'nulval', did you mean 'nullValue'") should be(true)
+    exception.getMessage.contains("Unable to find option 'datfrmt', did you mean 'dateFormat'") should be(true)
+  }
+
+  it should "throw an error if an invalid date format is provided" in {
+    val originalMap = Map[String, String](
+      "dateFormat" -> "yyyy-MM-dd HH:mm:ss.SSS zzz"
+    )
+
+    val inputMap = new CaseInsensitiveStringMap(originalMap.asJava)
+
+    val exception = the[CefParserOptionsException] thrownBy CefParserOptions.from(inputMap)
+
+    exception.getMessage.contains("Unable to parse date format 'yyyy-MM-dd HH:mm:ss.SSS zzz', valid options are") should be(true)
   }
 }

--- a/src/test/scala/com/bp/sds/cef/CefRecordWriterTests.scala
+++ b/src/test/scala/com/bp/sds/cef/CefRecordWriterTests.scala
@@ -1,0 +1,318 @@
+package com.bp.sds.cef
+
+import java.io.{ByteArrayOutputStream, OutputStreamWriter}
+import java.sql.Timestamp
+import java.util.TimeZone
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.types.{DoubleType, FloatType, IntegerType, LongType, StringType, StructField, StructType, TimestampType}
+import org.apache.spark.unsafe.types.UTF8String
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CefRecordWriterTests extends AnyFlatSpec with Matchers {
+  TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+
+  private val headerFields = Array(
+    StructField("CEFVersion", StringType, nullable = true),
+    StructField("DeviceVendor", StringType, nullable = true),
+    StructField("DeviceProduct", StringType, nullable = true),
+    StructField("DeviceVersion", StringType, nullable = true),
+    StructField("SignatureID", StringType, nullable = true),
+    StructField("Name", StringType, nullable = true),
+    StructField("Severity", StringType, nullable = true)
+  )
+
+  private def withOutputStream()(f: (ByteArrayOutputStream, OutputStreamWriter) => Unit): Unit = {
+    val out = new ByteArrayOutputStream()
+    val stream = new OutputStreamWriter(out, "UTF-8")
+
+    try {
+      f(out, stream)
+    } finally {
+      stream.close()
+      out.close()
+    }
+  }
+
+  behavior of "Writing records to CEF with invalid configuration"
+
+  it should "raise an error if the header fields contain null values" in {
+    val schema = StructType(headerFields)
+
+    val data = InternalRow.fromSeq(Seq(
+      UTF8String.fromString("cefversion"),
+      UTF8String.fromString("vendor"),
+      UTF8String.fromString("product"),
+      UTF8String.fromString("version"),
+      null,
+      UTF8String.fromString("name"),
+      UTF8String.fromString("sev")
+    ))
+
+    withOutputStream() { (_, stream) =>
+      val recordWriter = CefRecordWriter(schema, stream, CefParserOptions.from(Map[String, String]()))
+
+      val exception = the[UnsupportedOperationException] thrownBy recordWriter.writeRow(data)
+      exception.getMessage should be("Mandatory fields cannot contain null values")
+    }
+  }
+
+  behavior of "Writing a record with date formats"
+
+  private def testDateFormatting(format: Option[String], expectedFormattedDate: String): Unit = {
+    val schema = StructType(headerFields ++ Seq(StructField("cs1", TimestampType, nullable = true)))
+
+    val data = InternalRow.fromSeq(Seq(
+      UTF8String.fromString("cefversion"),
+      UTF8String.fromString("vendor"),
+      UTF8String.fromString("product"),
+      UTF8String.fromString("version"),
+      UTF8String.fromString("sigid"),
+      UTF8String.fromString("name"),
+      UTF8String.fromString("sev"),
+      DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf("2020-10-15 10:17:31.964"))
+    ))
+
+    withOutputStream() { (out, stream) =>
+      val options = format match {
+        case None => CefParserOptions.from(Map[String, String]())
+        case Some(fmt) => CefParserOptions.from(Map[String, String]("dateFormat" -> fmt))
+      }
+      val recordWriter = CefRecordWriter(schema, stream, options)
+      recordWriter.writeRow(data)
+      stream.flush()
+      out.flush()
+
+      out.toString should be(s"cefversion|vendor|product|version|sigid|name|sev|cs1=$expectedFormattedDate")
+    }
+  }
+
+  it should "default to writing with year, milliseconds, and timezone" in {
+    testDateFormatting(None, "Oct 15 2020 10:17:31.964 UTC")
+  }
+
+  it should "support writing with supported formats" in {
+    testDateFormatting(Some("MMM dd yyyy HH:mm:ss"), "Oct 15 2020 10:17:31")
+    testDateFormatting(Some("MMM dd yyyy HH:mm:ss.SSS"), "Oct 15 2020 10:17:31.964")
+    testDateFormatting(Some("MMM dd yyyy HH:mm:ss zzz"), "Oct 15 2020 10:17:31 UTC")
+    testDateFormatting(Some("MMM dd yyyy HH:mm:ss.SSS zzz"), "Oct 15 2020 10:17:31.964 UTC")
+    testDateFormatting(Some("MMM dd HH:mm:ss"), "Oct 15 10:17:31")
+    testDateFormatting(Some("MMM dd HH:mm:ss.SSS"), "Oct 15 10:17:31.964")
+    testDateFormatting(Some("MMM dd HH:mm:ss zzz"), "Oct 15 10:17:31 UTC")
+    testDateFormatting(Some("MMM dd HH:mm:ss.SSS zzz"), "Oct 15 10:17:31.964 UTC")
+    testDateFormatting(Some("millis"), "1602757051964000")
+  }
+
+  behavior of "Writing a DataFrame with valid data"
+
+  it should "write a record out to file with mandatory fields in the correct order" in {
+    val schema = StructType(headerFields ++ Seq(StructField("cs1", StringType, nullable = true)))
+
+    val data = InternalRow.fromSeq(Seq(
+      UTF8String.fromString("cefversion"),
+      UTF8String.fromString("vendor"),
+      UTF8String.fromString("product"),
+      UTF8String.fromString("version"),
+      UTF8String.fromString("sigid"),
+      UTF8String.fromString("name"),
+      UTF8String.fromString("sev"),
+      UTF8String.fromString("cs1value")
+    ))
+
+    withOutputStream() { (out, stream) =>
+      val recordWriter = CefRecordWriter(schema, stream, CefParserOptions.from(Map[String, String]()))
+      recordWriter.writeRow(data)
+      stream.flush()
+      out.flush()
+
+      out.toString should be("cefversion|vendor|product|version|sigid|name|sev|cs1=cs1value")
+    }
+  }
+
+  it should "write a record out to file with properly converted values" in {
+    val schema = StructType(headerFields ++ Seq(
+      StructField("rt", TimestampType, nullable = true),
+      StructField("cs1", IntegerType, nullable = true),
+      StructField("cs2", LongType, nullable = true),
+      StructField("cs3", FloatType, nullable = true),
+      StructField("cs4", DoubleType, nullable = true)
+    ))
+
+    val data = InternalRow.fromSeq(Seq(
+      UTF8String.fromString("cefversion"),
+      UTF8String.fromString("vendor"),
+      UTF8String.fromString("product"),
+      UTF8String.fromString("version"),
+      UTF8String.fromString("sigid"),
+      UTF8String.fromString("name"),
+      UTF8String.fromString("sev"),
+      DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf("2020-10-15 10:17:31.964")),
+      123,
+      1234567890L,
+      1.234F,
+      3.1415D
+    ))
+
+    withOutputStream() { (out, stream) =>
+      val recordWriter = CefRecordWriter(schema, stream, CefParserOptions.from(Map[String, String]()))
+      recordWriter.writeRow(data)
+      stream.flush()
+      out.flush()
+
+      out.toString should be("cefversion|vendor|product|version|sigid|name|sev|rt=Oct 15 2020 10:17:31.964 UTC cs1=123 cs2=1234567890 cs3=1.234 cs4=3.1415")
+    }
+  }
+
+  it should "write a record out to file with additional equality signs escaped" in {
+    val schema = StructType(headerFields ++ Seq(StructField("cs1", StringType, nullable = true)))
+
+    val data = InternalRow.fromSeq(Seq(
+      UTF8String.fromString("cefversion"),
+      UTF8String.fromString("vendor"),
+      UTF8String.fromString("product"),
+      UTF8String.fromString("version"),
+      UTF8String.fromString("sigid"),
+      UTF8String.fromString("name"),
+      UTF8String.fromString("sev"),
+      UTF8String.fromString("Issue from ip=127.0.0.01 signature=abc123==")
+    ))
+
+    withOutputStream() { (out, stream) =>
+      val recordWriter = CefRecordWriter(schema, stream, CefParserOptions.from(Map[String, String]()))
+      recordWriter.writeRow(data)
+      stream.flush()
+      out.flush()
+
+      out.toString should be("""cefversion|vendor|product|version|sigid|name|sev|cs1=Issue from ip\=127.0.0.01 signature\=abc123\=\=""")
+    }
+  }
+
+  it should "write a record out to file handling multi-line strings" in {
+    val schema = StructType(headerFields ++ Seq(StructField("cs1", StringType, nullable = true)))
+
+    val data = InternalRow.fromSeq(Seq(
+      UTF8String.fromString("cefversion"),
+      UTF8String.fromString("vendor"),
+      UTF8String.fromString("product"),
+      UTF8String.fromString("version"),
+      UTF8String.fromString("sigid"),
+      UTF8String.fromString("name"),
+      UTF8String.fromString("sev"),
+      UTF8String.fromString("""This
+                              |is
+                              |a
+                              |multiline \ value
+                              |
+                              |string
+                              |which=bad""".stripMargin)
+    ))
+
+    withOutputStream() { (out, stream) =>
+      val recordWriter = CefRecordWriter(schema, stream, CefParserOptions.from(Map[String, String]()))
+      recordWriter.writeRow(data)
+      stream.flush()
+      out.flush()
+
+      out.toString should be("""cefversion|vendor|product|version|sigid|name|sev|cs1=This\nis\na\nmultiline \\ value\n\nstring\nwhich\=bad""")
+    }
+  }
+
+  it should "write a record out to file handling multi-line and pipe values in header strings" in {
+    val schema = StructType(headerFields ++ Seq(StructField("cs1", StringType, nullable = true)))
+
+    val data = InternalRow.fromSeq(Seq(
+      UTF8String.fromString("cefversion | id"),
+      UTF8String.fromString("""vendor \ id"""),
+      UTF8String.fromString("product"),
+      UTF8String.fromString("version"),
+      UTF8String.fromString("sigid"),
+      UTF8String.fromString("name"),
+      UTF8String.fromString("""sev
+                              |id
+                              |3""".stripMargin),
+      UTF8String.fromString("Value")
+    ))
+
+    withOutputStream() { (out, stream) =>
+      val recordWriter = CefRecordWriter(schema, stream, CefParserOptions.from(Map[String, String]()))
+      recordWriter.writeRow(data)
+      stream.flush()
+      out.flush()
+
+      out.toString should be("""cefversion \| id|vendor \\ id|product|version|sigid|name|sev id 3|cs1=Value""")
+    }
+  }
+
+  it should "validate mandatory fields regardless of case" in {
+    val schema = StructType(headerFields.map(f => StructField(f.name.toLowerCase, f.dataType, f.nullable)))
+
+    val data = InternalRow.fromSeq(Seq(
+      UTF8String.fromString("cefversion"),
+      UTF8String.fromString("vendor"),
+      UTF8String.fromString("product"),
+      UTF8String.fromString("version"),
+      UTF8String.fromString("sigid"),
+      UTF8String.fromString("name"),
+      UTF8String.fromString("sev")
+    ))
+
+    withOutputStream() { (out, stream) =>
+      val recordWriter = CefRecordWriter(schema, stream, CefParserOptions.from(Map[String, String]()))
+      recordWriter.writeRow(data)
+      stream.flush()
+      out.flush()
+    }
+
+    succeed
+  }
+
+  it should "write out null values based on user specified value" in {
+    val schema = StructType(headerFields ++ Seq(StructField("cs1", StringType, nullable = true)))
+
+    val data = InternalRow.fromSeq(Seq(
+      UTF8String.fromString("cefversion"),
+      UTF8String.fromString("vendor"),
+      UTF8String.fromString("product"),
+      UTF8String.fromString("version"),
+      UTF8String.fromString("sigid"),
+      UTF8String.fromString("name"),
+      UTF8String.fromString("sev"),
+      null
+    ))
+
+    withOutputStream() { (out, stream) =>
+      val recordWriter = CefRecordWriter(schema, stream, CefParserOptions.from(Map[String, String]("nullValue" -> "NA")))
+      recordWriter.writeRow(data)
+      stream.flush()
+      out.flush()
+
+      out.toString should be("cefversion|vendor|product|version|sigid|name|sev|cs1=NA")
+    }
+  }
+
+  it should "write out a record in the correct header order" in {
+    val schema = StructType((headerFields ++ Seq(StructField("cs1", StringType, nullable = true))).reverse)
+
+    val data = InternalRow.fromSeq(Seq(
+      UTF8String.fromString("cefversion"),
+      UTF8String.fromString("vendor"),
+      UTF8String.fromString("product"),
+      UTF8String.fromString("version"),
+      UTF8String.fromString("sigid"),
+      UTF8String.fromString("name"),
+      UTF8String.fromString("sev"),
+      UTF8String.fromString("cs1Value")
+    ).reverse)
+
+    withOutputStream() { (out, stream) =>
+      val recordWriter = CefRecordWriter(schema, stream, CefParserOptions.from(Map[String, String]()))
+      recordWriter.writeRow(data)
+      stream.flush()
+      out.flush()
+
+      out.toString should be("cefversion|vendor|product|version|sigid|name|sev|cs1=cs1Value")
+    }
+  }
+}


### PR DESCRIPTION
Implements writer support, and introduces partitioned file support for reading files. This should allow the project to move to using the safe parser with full read mode support rather than the customised version which currently only supports permissive and fail fast. This also allows single, large files (non-compressed) to be split when reading which will allow for better utilisation of the users cluster.