### PR TITLE
Spark 3.1.2 update

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-$versions = @("3.0.1", "3.0.2", "3.1.1")
+$versions = @("3.0.1", "3.0.2", "3.1.1", "3.1.2")
 $jarPath = "./target/jars"
 
 Write-Host "Clearing existing jar artefacts" -ForegroundColor Green

--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,8 @@ libraryDependencies ++= Seq(
 )
 
 // Setup test dependencies and configuration
-parallelExecution in Test := false
-fork in Test := true
+Test / parallelExecution := false
+Test / fork := true
 
 libraryDependencies ++= Seq(
   "org.scalactic" %% "scalactic" % scalaTestVersion.value % Test,
@@ -44,5 +44,5 @@ val commonSettings = Seq(
       "2.12.10"
     }
   },
-  scalaTestVersion := "3.2.5"
+  scalaTestVersion := "3.2.9"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ libraryDependencies ++= Seq(
 
 // Define common settings for the library
 val commonSettings = Seq(
-  sparkVersion := System.getProperty("sparkVersion", "3.1.1"),
+  sparkVersion := System.getProperty("sparkVersion", "3.1.2"),
   scalaVersion := {
     if (sparkVersion.value < "3.0.0") {
       "2.11.12"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.5.3


### PR DESCRIPTION
Add Spark 3.1.2 as a build target, and uplift dependencies to latest versions